### PR TITLE
Define NOMINMAX before including windows.h

### DIFF
--- a/clock/game_clock.cpp
+++ b/clock/game_clock.cpp
@@ -1,4 +1,5 @@
-﻿#include <windows.h>
+﻿#define NOMINMAX
+#include <windows.h>
 #include <tchar.h>
 #include <dwmapi.h>
 #include <uxtheme.h>


### PR DESCRIPTION
## Summary
- define NOMINMAX before including windows.h in game_clock.cpp to prevent min/max macro pollution

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DUNICODE -D_UNICODE -c clock/game_clock.cpp -o /tmp/game_clock.o`


------
https://chatgpt.com/codex/tasks/task_e_68a59b2f03e483229bd88eccc351b701